### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/nicolas-lair/MoveMyWine/security/code-scanning/3](https://github.com/nicolas-lair/MoveMyWine/security/code-scanning/3)

To fix the problem, add an explicit `permissions` block that grants only the minimal privileges needed by this workflow. The shown job only checks out the repository and runs tests; `actions/checkout` and `uv run pytest` both work with `contents: read` permissions, so a read-only token is sufficient.

The best fix with no functional change is to define `permissions: contents: read` at the workflow root, so it applies to all jobs (currently just `test`). Concretely, in `.github/workflows/pytest.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `jobs:` block (after line 8 and before line 10). No imports or other code changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
